### PR TITLE
annotate_proteome writes out both nucl- and protein coordinates

### DIFF
--- a/cayman/annotate/crazy_annotator.py
+++ b/cayman/annotate/crazy_annotator.py
@@ -179,6 +179,9 @@ class CazyAnnotator:
         self.annotations_filtered['annotLength'] = self.annotations_filtered['end'] - self.annotations_filtered['start']
         self.annotations_filtered = self.annotations_filtered[[True if x >= 10 else False for x in list(self.annotations_filtered['annotLength'])]]
 
+        self.annotations_filtered['start_protein'] = self.annotations_filtered['start']
+        self.annotations_filtered['end_protein'] = self.annotations_filtered['end']
+
         ## TRANSFORM INTO NUCLEOTIDE COORDINATES!
         self.annotations_filtered['start'] = [(x * 3) - 2 for x in self.annotations_filtered['start']]
         self.annotations_filtered['end'] = [x * 3 for x in self.annotations_filtered['end']]


### PR DESCRIPTION
This fixes a stupid oversight on Quinten and my end. 

Briefly, the quantification part of the tool requires annotations on the nucleotide level (which is what `annotate_proteome` exclusively returns until this commit). 

So this commit leads to both nucleotide- and protein coordinates being returned by the annotator function, which should resolve the confusion.